### PR TITLE
Handle AppImages with icon only in root directory

### DIFF
--- a/lib/src/features/home/data/appimage_tools_repository.dart
+++ b/lib/src/features/home/data/appimage_tools_repository.dart
@@ -63,14 +63,13 @@ class AppimageToolsRepository {
     String desktopfilename =
         'aip_' + p.basenameWithoutExtension(newPath) + ".desktop";
 
-    String? desktopBasename;
+    String? iconName;
 
     // Copy desktop file
     try {
       var desktopFile = Directory(squashDir)
           .listSync()
           .firstWhere((element) => p.extension(element.path) == ".desktop");
-      desktopBasename = p.basenameWithoutExtension(desktopFile.path);
       await desktopFile
           .moveFile(_localPathService.applicationsDir + desktopfilename);
       String execPath = (await Process.run(
@@ -87,7 +86,7 @@ class AppimageToolsRepository {
           .split(' ')[0]
           .trim();
 
-      String iconName = (await Process.run(
+      iconName = (await Process.run(
         "grep",
         [
           "^Icon=",
@@ -143,13 +142,13 @@ class AppimageToolsRepository {
         ["-r", "./usr/share/icons", localShareDir],
         workingDirectory: squashDir,
       ));
-    } else if (desktopBasename != null) {
+    } else if (iconName != null) {
       // No icons in {squashDir}/usr/share/icons, search in top-level folder
       try {
         var icon = Directory(squashDir)
             .listSync()
             .firstWhere((element) =>
-                p.basenameWithoutExtension(element.path) == desktopBasename
+                p.basenameWithoutExtension(element.path) == iconName
                 && ['.png', '.svg'].contains(p.extension(element.path))
             );
 
@@ -170,7 +169,7 @@ class AppimageToolsRepository {
             sizeName = "scalable";
           }
 
-          var iconFilename = "aip_${desktopBasename}_${checksum}${iconExt}";
+          var iconFilename = "aip_${iconName}_${checksum}${iconExt}";
           icon.moveResolvedFile(
             localShareDir + "/icons/hicolor/${sizeName}/apps/${iconFilename}"
           );

--- a/lib/src/features/home/data/appimage_tools_repository.dart
+++ b/lib/src/features/home/data/appimage_tools_repository.dart
@@ -1,4 +1,5 @@
 import 'dart:io';
+import 'dart:ui';
 
 import 'package:appimagepool/src/features/home/data/local_path_provider.dart';
 import 'package:appimagepool/src/constants/constants.dart';
@@ -62,11 +63,14 @@ class AppimageToolsRepository {
     String desktopfilename =
         'aip_' + p.basenameWithoutExtension(newPath) + ".desktop";
 
+    String? desktopBasename;
+
     // Copy desktop file
     try {
       var desktopFile = Directory(squashDir)
           .listSync()
           .firstWhere((element) => p.extension(element.path) == ".desktop");
+      desktopBasename = p.basenameWithoutExtension(desktopFile.path);
       await desktopFile
           .moveFile(_localPathService.applicationsDir + desktopfilename);
       String execPath = (await Process.run(
@@ -139,6 +143,33 @@ class AppimageToolsRepository {
         ["-r", "./usr/share/icons", localShareDir],
         workingDirectory: squashDir,
       ));
+    } else if (desktopBasename != null) {
+      // No icons in {squashDir}/usr/share/icons, search in top-level folder
+      try {
+        var icon = Directory(squashDir)
+            .listSync()
+            .firstWhere((element) =>
+                p.basenameWithoutExtension(element.path) == desktopBasename
+                && ['.png', '.svg', '.xpm'].contains(p.extension(element.path))
+            );
+
+        if (icon is File) {
+          if (!icon.resolveSymbolicLinksSync().startsWith(squashDir + "/")) {
+            throw FileSystemException(
+              'Symlink for icon points out of the AppDir boundary'
+            );
+          }
+
+          var iconData = await decodeImageFromList(icon.readAsBytesSync());
+          int iconSize = iconData.height;
+          var iconFilename = "aip_${desktopBasename}_$checksum" + p.extension(icon.path);
+          icon.moveResolvedFile(
+            localShareDir + "/icons/hicolor/${iconSize}x${iconSize}/apps/${iconFilename}"
+          );
+        }
+      } catch (e) {
+        debugPrint("$e");
+      }
     }
 
     Directory(tempDir).delete(recursive: true);

--- a/lib/src/features/home/data/appimage_tools_repository.dart
+++ b/lib/src/features/home/data/appimage_tools_repository.dart
@@ -150,7 +150,7 @@ class AppimageToolsRepository {
             .listSync()
             .firstWhere((element) =>
                 p.basenameWithoutExtension(element.path) == desktopBasename
-                && ['.png', '.svg', '.xpm'].contains(p.extension(element.path))
+                && ['.png', '.svg'].contains(p.extension(element.path))
             );
 
         if (icon is File) {
@@ -160,11 +160,19 @@ class AppimageToolsRepository {
             );
           }
 
-          var iconData = await decodeImageFromList(icon.readAsBytesSync());
-          int iconSize = iconData.height;
-          var iconFilename = "aip_${desktopBasename}_$checksum" + p.extension(icon.path);
+          String sizeName;
+          String iconExt = p.extension(icon.path);
+          if (iconExt == '.png') {
+            var iconData = await decodeImageFromList(icon.readAsBytesSync());
+            int iconSize = iconData.height;
+            sizeName = "${iconSize}x${iconSize}";
+          } else {
+            sizeName = "scalable";
+          }
+
+          var iconFilename = "aip_${desktopBasename}_${checksum}${iconExt}";
           icon.moveResolvedFile(
-            localShareDir + "/icons/hicolor/${iconSize}x${iconSize}/apps/${iconFilename}"
+            localShareDir + "/icons/hicolor/${sizeName}/apps/${iconFilename}"
           );
         }
       } catch (e) {

--- a/lib/src/utils/extensions/file_move.dart
+++ b/lib/src/utils/extensions/file_move.dart
@@ -14,4 +14,9 @@ extension FileMoveExt on FileSystemEntity {
       return newFile;
     }
   }
+
+  Future moveResolvedFile(String newPath) async {
+    final resolvedFile = File(toFile.resolveSymbolicLinksSync());
+    return await resolvedFile.moveFile(newPath);
+  }
 }


### PR DESCRIPTION
Closes #110 

If the icons directory does not exist, the `integrate` method now looks for a `{myapp}.{ext}` icon file inside the root directory, where `{myapp}` is the basename of the desktop file (see [AppImage spec](https://docs.appimage.org/reference/appdir.html#general-description)) and `{ext}` is one of `.png`, `.svg` (see [Icon Theme spec](https://specifications.freedesktop.org/icon-theme-spec/icon-theme-spec-latest.html)).

If the icon is a `.png`, it must be placed in the `$HOME/.local/share/icons/{size}x{size}/apps/` directory, where `{size}` is one of the supported sizes of the hicolor theme. We determine the size by reading the image, similar to [what libappimage does](https://github.com/AppImageCommunity/libappimage/blob/e56c21b5387fde92cbb91c835e7aa16ab60b3879/src/libappimage/desktop_integration/integrator/Integrator.cpp#L240).

If the icon is a `.svg`, it is placed in `$HOME/.local/share/icons/scalable/apps/`.

The PR also extends `File` to have a `moveResolvedFile` method. It works similar to `moveFile` but if the file is a symlink moves the *target file* instead of the *symlink*.

## Discussion

1. Should we use the `Icon=` value from the desktop file and try suffixing with `.png`/`.svg` to find the icon file, instead of assuming it has the same basename as the desktop file?