### PR TITLE
Handle symlinked desktop files

### DIFF
--- a/lib/src/features/home/data/appimage_tools_repository.dart
+++ b/lib/src/features/home/data/appimage_tools_repository.dart
@@ -150,19 +150,22 @@ class AppimageToolsRepository {
     FileSystemEntity file,
   ) async {
     // Delete Icons
-    String? iconName = (await Process.run(
-      "grep",
-      [
-        "^Icon=",
-        _localPathService.applicationsDir + content[index] + ".desktop",
-      ],
-      runInShell: true,
-      workingDirectory: _localPathService.applicationsDir,
-    ))
-        .stdout
-        .split("=")
-        .elementAtOrNull(1)
-        ?.trim();
+    String? iconName;
+    try {
+      iconName = (await Process.run(
+        "grep",
+        [
+          "^Icon=",
+          _localPathService.applicationsDir + content[index] + ".desktop",
+        ],
+        runInShell: true,
+        workingDirectory: _localPathService.applicationsDir,
+      ))
+          .stdout
+          .split("=")[1]
+          .trim();
+    } on RangeError {}
+
     for (var icon
         in Directory(_localPathService.iconsDir).listSync(recursive: true)) {
       if (p.basenameWithoutExtension(icon.path) == iconName) {

--- a/lib/src/features/home/data/appimage_tools_repository.dart
+++ b/lib/src/features/home/data/appimage_tools_repository.dart
@@ -68,7 +68,7 @@ class AppimageToolsRepository {
           .listSync()
           .firstWhere((element) => p.extension(element.path) == ".desktop");
       await desktopFile
-          .moveFile(_localPathService.applicationsDir + desktopfilename);
+          .moveResolvedFile(_localPathService.applicationsDir + desktopfilename);
       String execPath = (await Process.run(
         "grep",
         [
@@ -150,7 +150,7 @@ class AppimageToolsRepository {
     FileSystemEntity file,
   ) async {
     // Delete Icons
-    String iconName = (await Process.run(
+    String? iconName = (await Process.run(
       "grep",
       [
         "^Icon=",
@@ -160,8 +160,9 @@ class AppimageToolsRepository {
       workingDirectory: _localPathService.applicationsDir,
     ))
         .stdout
-        .split("=")[1]
-        .trim();
+        .split("=")
+        .elementAtOrNull(1)
+        ?.trim();
     for (var icon
         in Directory(_localPathService.iconsDir).listSync(recursive: true)) {
       if (p.basenameWithoutExtension(icon.path) == iconName) {


### PR DESCRIPTION
Depends on #112 to use `File.moveResolvedFile` extension

Closes #111

* Resolves desktop file to copy it into `.local/share/applications/` instead of a symlink. 
* Graceful disintegration for AppImages with symlink desktop files that were previously integrated improperly.